### PR TITLE
Feature/Authorization_API_Tests

### DIFF
--- a/InnoClinic.Authorization.API/Controllers/AuthController.cs
+++ b/InnoClinic.Authorization.API/Controllers/AuthController.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 using AutoMapper;
 
 using IdentityServer4;
@@ -16,6 +18,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace InnoClinic.Authorization.API.Controllers;
 
+[ExcludeFromCodeCoverage]
 public class AuthController : Controller
 {
     private readonly SignInManager<Account> _signInManager;

--- a/InnoClinic.Authorization.API/Program.cs
+++ b/InnoClinic.Authorization.API/Program.cs
@@ -45,7 +45,7 @@ namespace InnoClinic.Authorization.API
             });
 
             builder.Services.AddScoped<DataSeeder>();
-            builder.Services.AddScoped<ProfilesApiHelper>();
+            builder.Services.AddScoped<IProfilesApiHelper, ProfilesApiHelper>();
             builder.Services.AddScoped<IAccountService, AccountService>();
             builder.Services.AddScoped<IEmailService, EmailService>();
             builder.Services.AddScoped<IMessageService, EmailService>();

--- a/InnoClinic.Authorization.App/Configuration/EmailSettings.cs
+++ b/InnoClinic.Authorization.App/Configuration/EmailSettings.cs
@@ -8,5 +8,6 @@
         public int SmtpPort { get; set; }
         public string CredUserName { get; set; }
         public string CredPassword { get; set; }
+        public bool EnableSsl { get; set; } = true;
     }
 }

--- a/InnoClinic.Authorization.App/Helpers/IProfilesApiHelper.cs
+++ b/InnoClinic.Authorization.App/Helpers/IProfilesApiHelper.cs
@@ -1,0 +1,9 @@
+﻿
+namespace InnoClinic.Authorization.Business.Helpers
+{
+    public interface IProfilesApiHelper
+    {
+        Task<HttpResponseMessage> GetDoctorProfileStatusAsync(Guid accountId);
+        Task<HttpResponseMessage> GetProfileTypeAsync(Guid accountId);
+    }
+}

--- a/InnoClinic.Authorization.App/Helpers/ProfilesApiHelper.cs
+++ b/InnoClinic.Authorization.App/Helpers/ProfilesApiHelper.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace InnoClinic.Authorization.Business.Helpers
 {
-    public class ProfilesApiHelper
+    public class ProfilesApiHelper : IProfilesApiHelper
     {
         private readonly string _baseUrl = $"{AppUrls.ProfilesUrl}/api";
         private readonly string _doctorsEndpoint = "Doctors";

--- a/InnoClinic.Authorization.App/Services/AccountService.cs
+++ b/InnoClinic.Authorization.App/Services/AccountService.cs
@@ -17,13 +17,13 @@ namespace InnoClinic.Authorization.Business.Services
         private readonly ILogger<AccountService> _logger;
         private readonly UserManager<Account> _userManager;
         private readonly IIdentityServerInteractionService _interactionService;
-        private readonly ProfilesApiHelper _profilesApiHelper;
+        private readonly IProfilesApiHelper _profilesApiHelper;
 
         public AccountService(
             ILogger<AccountService> logger,
             UserManager<Account> userManager,
             IIdentityServerInteractionService interactionService,
-            ProfilesApiHelper profilesApiHelper)
+            IProfilesApiHelper profilesApiHelper)
         {
             _logger = logger ??
                 throw new DiNullReferenceException(nameof(logger));
@@ -70,7 +70,7 @@ namespace InnoClinic.Authorization.Business.Services
 
             LogMethodExit(Logger.WarningFailedDoAction, nameof(GetProfileTypeAsync));
 
-            return ProfileType.UnknownProfile;
+            throw new ProfileTypeApiException();
         }
 
         public async Task<IClientIdResult> GetClientIdAsync(string returnUrl)

--- a/InnoClinic.Authorization.App/Services/EmailService.cs
+++ b/InnoClinic.Authorization.App/Services/EmailService.cs
@@ -68,7 +68,7 @@ namespace InnoClinic.Authorization.Business.Services
                 Credentials = new NetworkCredential(
                     emailConfig.CredUserName,
                     emailConfig.CredPassword),
-                EnableSsl = true
+                EnableSsl = emailConfig.EnableSsl
             };
 
             Logger.DebugPrepareToEnter(_logger, nameof(SmtpClient.SendMailAsync));

--- a/InnoClinic.Authorization.Tests/AccountServiceTests.cs
+++ b/InnoClinic.Authorization.Tests/AccountServiceTests.cs
@@ -1,0 +1,332 @@
+﻿using System.Net;
+
+using IdentityServer4.Models;
+using IdentityServer4.Services;
+
+using InnoClinic.Authorization.Business.Helpers;
+using InnoClinic.Authorization.Business.Services;
+using InnoClinic.Authorization.Domain.Entities.Users;
+using InnoClinic.Shared;
+using InnoClinic.Shared.Exceptions;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace InnoClinic.Authorization.Tests
+{
+    [TestFixture]
+    public class AccountServiceTests
+    {
+        private const string _returnUrl = "https://app/callback";
+        private const string _diErrorMessagePart = "Dependency Injection failed";
+        private Mock<ILogger<AccountService>> _loggerMock;
+        private Mock<UserManager<Account>> _userManagerMock;
+        private Mock<IIdentityServerInteractionService> _interactionServiceMock;
+        private Mock<IProfilesApiHelper> _profilesApiHelperMock;
+        private AccountService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _loggerMock = new Mock<ILogger<AccountService>>();
+
+            // UserManager requires(!) a IUserStore<Account> plus 8 optional params.
+            var userStore = new Mock<IUserStore<Account>>();
+            _userManagerMock = new Mock<UserManager<Account>>(
+                            userStore.Object,
+                            null, null, null, null, null, null, null, null);
+            _interactionServiceMock = new Mock<IIdentityServerInteractionService>();
+            _profilesApiHelperMock = new Mock<IProfilesApiHelper>();
+
+            _service = new AccountService(
+                _loggerMock.Object,
+                _userManagerMock.Object,
+                _interactionServiceMock.Object,
+                _profilesApiHelperMock.Object
+            );
+        }
+
+        #region Constructor DI Guards
+
+        [Test]
+        public void Constructor_NullLogger_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new AccountService(
+                    null!,
+                    _userManagerMock.Object,
+                    _interactionServiceMock.Object,
+                    _profilesApiHelperMock.Object));
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullUserManager_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new AccountService(
+                    _loggerMock.Object,
+                    null!,
+                    _interactionServiceMock.Object,
+                    _profilesApiHelperMock.Object));
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullInteractionService_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new AccountService(
+                    _loggerMock.Object,
+                    _userManagerMock.Object,
+                    null!,
+                    _profilesApiHelperMock.Object));
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullProfilesApiHelper_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new AccountService(
+                    _loggerMock.Object,
+                    _userManagerMock.Object,
+                    _interactionServiceMock.Object,
+                    null!));
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        #endregion
+
+        #region IsEmailExistsAsync
+
+        [Test]
+        public async Task IsEmailExistsAsync_WhenUserFound_ReturnsTrue()
+        {
+            const string email = "user@example.com";
+            _userManagerMock
+                .Setup(x => x.FindByEmailAsync(email))
+                .ReturnsAsync(new Account { Email = email });
+
+            var exists = await _service.IsEmailExistsAsync(email);
+
+            Assert.That(exists, Is.EqualTo(true));
+        }
+
+        [Test]
+        public async Task IsEmailExistsAsync_WhenUserNotFound_ReturnsFalse()
+        {
+            const string email = "missing@example.com";
+            _userManagerMock
+                .Setup(x => x.FindByEmailAsync(email))
+                .ReturnsAsync((Account?)null);
+
+            var exists = await _service.IsEmailExistsAsync(email);
+
+            Assert.That(exists, Is.EqualTo(false));
+        }
+
+        #endregion
+
+        #region IsDoctorProfileActiveAsync
+
+        [Test]
+        public async Task IsDoctorProfileActiveAsync_WhenHelperReturnsSuccess_True()
+        {
+            var accountId = Guid.NewGuid();
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            _profilesApiHelperMock
+                .Setup(x => x.GetDoctorProfileStatusAsync(accountId))
+                .ReturnsAsync(response);
+
+            var isActive = await _service.IsDoctorProfileActiveAsync(accountId);
+
+            Assert.That(isActive, Is.EqualTo(true));
+        }
+
+        [Test]
+        public async Task IsDoctorProfileActiveAsync_WhenHelperReturnsFailure_False()
+        {
+            var accountId = Guid.NewGuid();
+            var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+            _profilesApiHelperMock
+                .Setup(x => x.GetDoctorProfileStatusAsync(accountId))
+                .ReturnsAsync(response);
+
+            var isActive = await _service.IsDoctorProfileActiveAsync(accountId);
+
+            Assert.That(isActive, Is.EqualTo(false));
+        }
+
+        #endregion
+
+        #region GetProfileTypeAsync
+
+        [Test]
+        public async Task GetProfileTypeAsync_WhenSuccessAndValidEnum_ReturnsParsed()
+        {
+            var accountId = Guid.NewGuid();
+            var content = new StringContent(ProfileType.Doctor.ToString());
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+
+            _profilesApiHelperMock
+                .Setup(x => x.GetProfileTypeAsync(accountId))
+                .ReturnsAsync(response);
+
+            var result = await _service.GetProfileTypeAsync(accountId);
+
+            Assert.That(result, Is.EqualTo(ProfileType.Doctor));
+        }
+
+        [Test]
+        public void GetProfileTypeAsync_WhenSuccessAndInvalidEnum_Throws()
+        {
+            var accountId = Guid.NewGuid();
+            var content = new StringContent("NonExistent");
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+
+            _profilesApiHelperMock
+                .Setup(x => x.GetProfileTypeAsync(accountId))
+                .ReturnsAsync(response);
+
+            Assert.ThrowsAsync<ProfileTypeApiException>(async () =>
+                await _service.GetProfileTypeAsync(accountId));
+        }
+
+        [Test]
+        public void GetProfileTypeAsync_WhenFailureStatusCode_Throws()
+        {
+            var accountId = Guid.NewGuid();
+            var content = new StringContent(ProfileType.Receptionist.ToString());
+            var response = new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = content };
+
+            _profilesApiHelperMock
+                .Setup(x => x.GetProfileTypeAsync(accountId))
+                .ReturnsAsync(response);
+
+            Assert.ThrowsAsync<ProfileTypeApiException>(async () =>
+                await _service.GetProfileTypeAsync(accountId));
+        }
+
+        #endregion
+
+        #region GetClientIdAsync
+
+        [Test]
+        public async Task GetClientIdAsync_WhenContextNull_ReturnsError()
+        {
+            _interactionServiceMock
+                .Setup(x => x.GetAuthorizationContextAsync(_returnUrl))
+                .ReturnsAsync((AuthorizationRequest?)null);
+
+            var result = await _service.GetClientIdAsync(_returnUrl);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsSuccess, Is.EqualTo(false));
+                Assert.That(result.ErrorMessage, Is.Not.Null);
+            });
+            Assert.That(result.ErrorMessage.Header, Does.Contain("Invalid page access"));
+        }
+
+        [Test]
+        public async Task GetClientIdAsync_WhenClientNull_ReturnsError()
+        {
+            var ctx = new AuthorizationRequest { Client = null };
+            _interactionServiceMock
+                .Setup(x => x.GetAuthorizationContextAsync(_returnUrl))
+                .ReturnsAsync(ctx);
+
+            var result = await _service.GetClientIdAsync(_returnUrl);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsSuccess, Is.EqualTo(false));
+                Assert.That(result.ErrorMessage, Is.Not.Null);
+            });
+            Assert.That(result.ErrorMessage.Header, Does.Contain("Invalid Client"));
+        }
+
+        [Test]
+        public async Task GetClientIdAsync_WhenClientIdNull_ReturnsError()
+        {
+            var ctx = new AuthorizationRequest
+            {
+                Client = new Client { ClientId = null }
+            };
+            _interactionServiceMock
+                .Setup(x => x.GetAuthorizationContextAsync(_returnUrl))
+                .ReturnsAsync(ctx);
+
+            var result = await _service.GetClientIdAsync(_returnUrl);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsSuccess, Is.EqualTo(false));
+                Assert.That(result.ErrorMessage, Is.Not.Null);
+            });
+            Assert.That(result.ErrorMessage.Header, Does.Contain("Invalid Client"));
+        }
+
+        [Test]
+        public async Task GetClientIdAsync_WhenClientIdProvided_ReturnsSuccess()
+        {
+            const string expectedClientId = "inno-client";
+            var ctx = new AuthorizationRequest
+            {
+                Client = new Client { ClientId = expectedClientId }
+            };
+            _interactionServiceMock
+                .Setup(x => x.GetAuthorizationContextAsync(_returnUrl))
+                .ReturnsAsync(ctx);
+
+            var result = await _service.GetClientIdAsync(_returnUrl);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsSuccess, Is.EqualTo(true));
+                Assert.That(result.ClientId, Is.EqualTo(expectedClientId));
+            });
+        }
+
+        #endregion
+
+        #region UpdateSelfCreatedUserAsync
+
+        [Test]
+        public async Task UpdateSelfCreatedUserAsync_SetsAuditFieldsAndCallsUserManager()
+        {
+            var id = Guid.NewGuid();
+            var user = new Account
+            {
+                Id = id,
+                CreatedBy = Guid.Empty,
+                UpdatedBy = Guid.Empty
+            };
+            var expected = IdentityResult.Success;
+
+            _userManagerMock
+                .Setup(x => x.UpdateAsync(It.IsAny<Account>()))
+                .ReturnsAsync(expected);
+
+            var result = await _service.UpdateSelfCreatedUserAsync(user);
+
+            Assert.That(result, Is.EqualTo(expected));
+
+            _userManagerMock.Verify(um =>
+                um.UpdateAsync(It.Is<Account>(u =>
+                    u.CreatedBy == id &&
+                    u.UpdatedBy == id
+                )),
+                Times.Once);
+        }
+
+        #endregion
+    }
+}

--- a/InnoClinic.Authorization.Tests/EmailServiceTests.cs
+++ b/InnoClinic.Authorization.Tests/EmailServiceTests.cs
@@ -64,6 +64,40 @@ namespace InnoClinic.Authorization.Tests
             _smtpServer.Dispose();
         }
 
+        #region Constructor DI Guards
+
+        [Test]
+        public void Constructor_NullConfiguration_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new EmailService(null!, _userManagerMock.Object, _loggerMock.Object)
+            );
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullUserManager_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new EmailService(_config, null!, _loggerMock.Object)
+            );
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullLogger_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new EmailService(_config, _userManagerMock.Object, null!)
+            );
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        #endregion
+
         [Test]
         public async Task SendVerificationMessageAsync_EmailIsReceivedByMockServer()
         {
@@ -119,36 +153,6 @@ namespace InnoClinic.Authorization.Tests
             );
 
             Assert.That(ex.Message, Does.Contain(userId));
-        }
-
-        [Test]
-        public void Constructor_NullConfiguration_Throws()
-        {
-            var ex = Assert.Throws<DiNullReferenceException>(() =>
-                new EmailService(null!, _userManagerMock.Object, _loggerMock.Object)
-            );
-
-            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
-        }
-
-        [Test]
-        public void Constructor_NullUserManager_Throws()
-        {
-            var ex = Assert.Throws<DiNullReferenceException>(() =>
-                new EmailService(_config, null!, _loggerMock.Object)
-            );
-
-            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
-        }
-
-        [Test]
-        public void Constructor_NullLogger_Throws()
-        {
-            var ex = Assert.Throws<DiNullReferenceException>(() =>
-                new EmailService(_config, _userManagerMock.Object, null!)
-            );
-
-            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
         }
     }
 }

--- a/InnoClinic.Authorization.Tests/EmailServiceTests.cs
+++ b/InnoClinic.Authorization.Tests/EmailServiceTests.cs
@@ -1,0 +1,154 @@
+﻿using InnoClinic.Authorization.Business.Services;
+using InnoClinic.Authorization.Domain.Entities.Users;
+using InnoClinic.Shared.Exceptions;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using netDumbster.smtp;
+
+namespace InnoClinic.Authorization.Tests
+{
+    [TestFixture]
+    public class EmailServiceTests
+    {
+        private const string _diErrorMessagePart = "Dependency Injection failed";
+        private SimpleSmtpServer _smtpServer;
+        private IConfiguration _config;
+        private Mock<UserManager<Account>> _userManagerMock;
+        private Mock<ILogger<EmailService>> _loggerMock;
+        private EmailService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _smtpServer = SimpleSmtpServer.Start(2525);
+
+            var inMemorySettings = new List<KeyValuePair<string, string?>>()
+            {
+                new("EmailSettings:From",         "noreply@innoclinic.com"),
+                new("EmailSettings:DisplayName",  "InnoClinic"),
+                new("EmailSettings:SmtpHost",     "localhost"),
+                new("EmailSettings:SmtpPort",     "2525"),
+                new("EmailSettings:CredUserName", null),
+                new("EmailSettings:CredPassword", null),
+                new("EmailSettings:EnableSsl",     "false")
+            };
+
+            _config = new ConfigurationBuilder()
+                                .AddInMemoryCollection(inMemorySettings)
+                                .Build();
+
+            // UserManager requires(!) a IUserStore<Account> plus 8 optional params.
+            var userStoreMock = new Mock<IUserStore<Account>>();
+            _userManagerMock = new Mock<UserManager<Account>>(
+                userStoreMock.Object, null, null, null, null, null, null, null, null
+            );
+
+            _loggerMock = new Mock<ILogger<EmailService>>();
+
+            _service = new EmailService(
+                _config,
+                _userManagerMock.Object,
+                _loggerMock.Object
+            );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _smtpServer.Stop();
+            _smtpServer.Dispose();
+        }
+
+        [Test]
+        public async Task SendVerificationMessageAsync_EmailIsReceivedByMockServer()
+        {
+            var recipient = "test@localhost";
+            var link = "http://confirm-link.com";
+
+            await _service.SendVerificationMessageAsync(recipient, link);
+
+            Assert.That(_smtpServer.ReceivedEmailCount, Is.EqualTo(1));
+
+            var received = _smtpServer.ReceivedEmail[0];
+            var body = received.MessageParts[0].BodyData;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(body.Contains("Confirm Email"), Is.EqualTo(true));
+                Assert.That(body.Contains(link), Is.EqualTo(true));
+            });
+        }
+
+        [Test]
+        public async Task ConfirmUserContactMethod_ReturnsTrue_WhenConfirmationSucceeds()
+        {
+            var userId = Guid.NewGuid();
+            var token = "valid-token";
+            var user = new Account { Id = userId };
+
+            _userManagerMock
+                .Setup(m => m.FindByIdAsync(userId.ToString()))
+                .ReturnsAsync(user);
+
+            _userManagerMock
+                .Setup(m => m.ConfirmEmailAsync(user, token))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var result = await _service.ConfirmUserContactMethod(userId.ToString(), token);
+
+            Assert.That(result, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void ConfirmUserContactMethod_Throws_WhenUserNotFound()
+        {
+            var userId = "missing-user";
+            var token = "any-token";
+
+            _userManagerMock
+                .Setup(m => m.FindByIdAsync(userId))
+                .ReturnsAsync((Account?)null);
+
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () =>
+                await _service.ConfirmUserContactMethod(userId, token)
+            );
+
+            Assert.That(ex.Message, Does.Contain(userId));
+        }
+
+        [Test]
+        public void Constructor_NullConfiguration_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new EmailService(null!, _userManagerMock.Object, _loggerMock.Object)
+            );
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullUserManager_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new EmailService(_config, null!, _loggerMock.Object)
+            );
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+
+        [Test]
+        public void Constructor_NullLogger_Throws()
+        {
+            var ex = Assert.Throws<DiNullReferenceException>(() =>
+                new EmailService(_config, _userManagerMock.Object, null!)
+            );
+
+            Assert.That(ex.Message, Does.Contain(_diErrorMessagePart));
+        }
+    }
+}

--- a/InnoClinic.Authorization.Tests/EmployeeUiLoginTests.cs
+++ b/InnoClinic.Authorization.Tests/EmployeeUiLoginTests.cs
@@ -1,0 +1,105 @@
+﻿using System.Text;
+
+using OpenQA.Selenium;
+using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.Support.UI;
+
+using SeleniumExtras.WaitHelpers;
+
+namespace InnoClinic.Authorization.Tests
+{
+    [TestFixture]
+    public class EmployeeUiLoginTests
+    {
+        private FirefoxDriver _driver;
+        private StringBuilder _verificationErrors;
+        private readonly string _baseUrl = "https://localhost:4300";
+        private readonly string _emailFieldName = "Email";
+        private readonly string _passwordFieldName = "Password";
+        private readonly string _validationErrorsFieldName = "validation-summary-errors validation-summary-errors";
+        private readonly string _messageHeaderFieldName = "message-header";
+
+        [SetUp]
+        public void SetupTest()
+        {
+            _driver = new FirefoxDriver();
+            _verificationErrors = new StringBuilder();
+        }
+
+        [TearDown]
+        public void TeardownTest()
+        {
+            try
+            {
+                _driver?.Quit();
+                _driver?.Dispose();
+            }
+            catch (Exception)
+            {
+                // Ignore errors if unable to close the browser
+            }
+
+            Assert.That(_verificationErrors.ToString(), Is.EqualTo(""));
+        }
+
+        [Test]
+        public async Task LoginAsDoctorActiveProfileTest()
+        {
+            await _driver.Navigate().GoToUrlAsync(_baseUrl);
+            await Task.Delay(1000);
+            await EnterValueToField(_emailFieldName, "elena.volkova@example.com");
+            await EnterValueToField(_passwordFieldName, "123456");
+            await Task.Delay(300);
+            _driver.FindElement(By.XPath("//button[@type='submit']")).Click();
+
+            await Task.Delay(2000);
+            Assert.That(_driver.Url, Is.EqualTo($"{_baseUrl}/login-success"));
+        }
+
+        [Test]
+        public async Task LoginAsDoctorInactiveProfileTest()
+        {
+            await _driver.Navigate().GoToUrlAsync(_baseUrl);
+            await Task.Delay(1000);
+            await EnterValueToField(_emailFieldName, "sergey.ivanov@example.com");
+            await EnterValueToField(_passwordFieldName, "Aa123456!");
+            await Task.Delay(300);
+            _driver.FindElement(By.XPath("//button[@type='submit']")).Click();
+
+            await Task.Delay(2000);
+
+            var messageOnThePage = _driver.FindElement(
+                By.XPath($"//div[@class='{_validationErrorsFieldName}']")).Text;
+            Assert.That(messageOnThePage, Is.EqualTo("Either an email or a password is incorrect"));
+        }
+
+        [Test]
+        public async Task LoginAsPatientProfileTest()
+        {
+            await _driver.Navigate().GoToUrlAsync(_baseUrl);
+            await Task.Delay(1000);
+            await EnterValueToField(_emailFieldName, "maxim.petrov@patientmail.com");
+            await EnterValueToField(_passwordFieldName, "Aa123456!");
+            await Task.Delay(300);
+            _driver.FindElement(By.XPath("//button[@type='submit']")).Click();
+
+            await Task.Delay(2000);
+
+            var messageOnThePage = _driver.FindElement(
+                By.XPath($"//div[@class='{_messageHeaderFieldName}']")).Text;
+            Assert.That(messageOnThePage, Is.EqualTo($"Invalid Profile Type"));
+        }
+
+        private async Task EnterValueToField(string fieldName, string value)
+        {
+            var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+            var field = wait.Until(ExpectedConditions.ElementToBeClickable(By.Id(fieldName)));
+
+            field.Click();
+            await Task.Delay(300);
+            field.Clear();
+            await Task.Delay(300);
+            field.SendKeys(value);
+        }
+    }
+}

--- a/InnoClinic.Authorization.Tests/InnoClinic.Authorization.Tests.csproj
+++ b/InnoClinic.Authorization.Tests/InnoClinic.Authorization.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.35.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InnoClinic.Authorization.API\InnoClinic.Authorization.API.csproj" />
+    <ProjectReference Include="..\InnoClinic.Authorization.App\InnoClinic.Authorization.Business.csproj" />
+    <ProjectReference Include="..\InnoClinic.Authorization.Domain\InnoClinic.Authorization.Domain.csproj" />
+    <ProjectReference Include="..\InnoClinic.Authorization.Infrastructure\InnoClinic.Authorization.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/InnoClinic.Authorization.Tests/InnoClinic.Authorization.Tests.csproj
+++ b/InnoClinic.Authorization.Tests/InnoClinic.Authorization.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="netDumbster" Version="3.1.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/InnoClinic.Authorization.Tests/InnoClinic.Authorization.Tests.csproj
+++ b/InnoClinic.Authorization.Tests/InnoClinic.Authorization.Tests.csproj
@@ -12,10 +12,12 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.35.0" />
+    <PackageReference Include="WireMock.Net" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/InnoClinic.Authorization.Tests/ProfilesApiHelperTests.cs
+++ b/InnoClinic.Authorization.Tests/ProfilesApiHelperTests.cs
@@ -1,0 +1,126 @@
+﻿using System.Net;
+using System.Reflection;
+
+using InnoClinic.Authorization.Business.Helpers;
+using InnoClinic.Shared.Exceptions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace InnoClinic.Authorization.Tests
+{
+    public class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public TestHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return _client;
+        }
+    }
+
+    [TestFixture]
+    public class ProfilesApiHelperTests
+    {
+        private WireMockServer _server;
+        private ProfilesApiHelper _helper;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _server = WireMockServer.Start();
+
+            _server
+                .Given(Request.Create()
+                    .WithPath("/api/Doctors/*/status")
+                    .UsingGet())
+                .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("DoctorStatus"));
+
+            _server
+                .Given(Request.Create()
+                    .WithPath("/api/Profiles/*/type")
+                    .UsingGet())
+                .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("ProfileType"));
+
+            var httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(_server.Urls[0])
+            };
+
+            var httpClientFactory = new TestHttpClientFactory(httpClient);
+            var logger = new NullLogger<ProfilesApiHelper>();
+
+            _helper = new ProfilesApiHelper(httpClientFactory, logger);
+
+            var baseUrlField = typeof(ProfilesApiHelper)
+                .GetField("_baseUrl", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            baseUrlField.SetValue(
+                _helper,
+                $"{_server.Urls[0]}/api"
+            );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _server.Stop();
+            _server.Dispose();
+        }
+
+        [Test]
+        public async Task GetDoctorProfileStatusAsync_ReturnsExpectedContentAndStatusCode()
+        {
+            var accountId = Guid.NewGuid();
+
+            var response = await _helper.GetDoctorProfileStatusAsync(accountId);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.That(body, Is.EqualTo("DoctorStatus"));
+        }
+
+        [Test]
+        public async Task GetProfileTypeAsync_ReturnsExpectedContentAndStatusCode()
+        {
+            var accountId = Guid.NewGuid();
+
+            var response = await _helper.GetProfileTypeAsync(accountId);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.That(body, Is.EqualTo("ProfileType"));
+        }
+
+        [Test]
+        public void Constructor_NullHttpClientFactory_ThrowsDiNullReferenceException()
+        {
+            var logger = new NullLogger<ProfilesApiHelper>();
+            Assert.Throws<DiNullReferenceException>(
+                () => new ProfilesApiHelper(null, logger)
+            );
+        }
+
+        [Test]
+        public void Constructor_NullLogger_ThrowsDiNullReferenceException()
+        {
+            var httpClient = new HttpClient { BaseAddress = new Uri("http://localhost") };
+            var factory = new TestHttpClientFactory(httpClient);
+            Assert.Throws<DiNullReferenceException>(
+                () => new ProfilesApiHelper(factory, null)
+            );
+        }
+    }
+}

--- a/InnoClinic.Shared/Exceptions/ProfileTypeApiException.cs
+++ b/InnoClinic.Shared/Exceptions/ProfileTypeApiException.cs
@@ -1,0 +1,16 @@
+﻿namespace InnoClinic.Shared.Exceptions
+{
+    /// <summary>
+    /// Thrown when an attempt to retrieve a profile type from an external API fails due to an internal server error (HTTP 500)
+    /// or when the API returns an invalid profile type.
+    /// </summary>
+    public class ProfileTypeApiException : Exception
+    {
+        /// <summary>
+        /// Thrown when an attempt to retrieve a profile type from an external API fails due to an internal server error (HTTP 500)
+        /// or when the API returns an invalid profile type.
+        /// </summary>
+        public ProfileTypeApiException() : 
+            base("Failed to retrieve a valid profile type: API responded with an internal server error (HTTP 500) or returned an invalid profile type.") { }
+    }
+}

--- a/InnoClinic.sln
+++ b/InnoClinic.sln
@@ -26,6 +26,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{B22F33
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InnoClinic.Shared", "InnoClinic.Shared\InnoClinic.Shared.csproj", "{5CE0A046-BC0F-4E74-BB7C-A4EDF5D69DB5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InnoClinic.Authorization.Tests", "InnoClinic.Authorization.Tests\InnoClinic.Authorization.Tests.csproj", "{36B3EF5B-E560-4465-85E9-B7459851365E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1547D8A0-E34A-484D-A96D-48952183A151}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +72,10 @@ Global
 		{5CE0A046-BC0F-4E74-BB7C-A4EDF5D69DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CE0A046-BC0F-4E74-BB7C-A4EDF5D69DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CE0A046-BC0F-4E74-BB7C-A4EDF5D69DB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36B3EF5B-E560-4465-85E9-B7459851365E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36B3EF5B-E560-4465-85E9-B7459851365E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36B3EF5B-E560-4465-85E9-B7459851365E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36B3EF5B-E560-4465-85E9-B7459851365E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,6 +90,7 @@ Global
 		{46F3A441-E865-4C88-B4BB-6A1E73727EBD} = {CEEE3882-CA7D-4E5F-B4E4-1C04F524D557}
 		{27BE034A-D585-4C24-AAB7-D5A39F242EAD} = {CEEE3882-CA7D-4E5F-B4E4-1C04F524D557}
 		{5CE0A046-BC0F-4E74-BB7C-A4EDF5D69DB5} = {B22F33AB-2333-4D71-9C64-76C98587C2E9}
+		{36B3EF5B-E560-4465-85E9-B7459851365E} = {1547D8A0-E34A-484D-A96D-48952183A151}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {65470075-91E2-407E-9653-D159956140FB}


### PR DESCRIPTION
# feat: Add tests for Authorization API (#11)

_Cover EmployeeUI login process, Account and Email services and ProfilesApiHelper class. Also add ProfileTypeApiException and change behavior GetProfileTypeAsync method in the Account Service._

### *refactor(Authorization.Tests): code style fixes and refactoring

### *refactor(Authorization.Tests): add EmailService tests

### *refactor(): add new tests and refactor AuthorizationAPI
Add Moq support to the Authorization.Tests project
Add WireMock.Net support to the Authorization.Tests project
Add tests for ProfilesApiHelper and AccountService
Add IProfilesApiHelper interface for test purposes
Add ProfileTypeApiException to the InnoClinic.Shared project
Refactor GetProfileTypeAsync method in the AccountService:
this method now throws ProfileTypeApiException when an external API returns an internal server error (HTTP 500)
or invalid profile type as an answer to GetProfileType request
Refactor AuthController:
it now shows the specified error message page to the user in case when ProfileTypeApiException was thrown in the process of retrieving profile type

BREAKING CHANGE: GetProfileTypeAsync method in the AccountService now throws error instead of returning UnknownProfile type when retrieving profile type fails

### *refactor(EmployeeUiLoginTests): upd old tests and add new ones

### *feat: add Selenium tests support to the AuthorizationAPI
Add InnoClinic.Authorization.Tests project
Add EmployeeUiLoginTests class to the Authorization.Tests project
Add a few tests to the EmployeeUiLoginTests class